### PR TITLE
ATR-1785 Bumping go version to 1.18 for go-build-test

### DIFF
--- a/.github/workflows/go-build-test.yaml
+++ b/.github/workflows/go-build-test.yaml
@@ -1,5 +1,5 @@
 name: Go Build and Test
-on: 
+on:
   workflow_call:
     inputs:
       go_project_dir_root:
@@ -14,8 +14,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16.x'
-      - name: Get Dependencies 
+          go-version: '1.18.x'
+      - name: Get Dependencies
         working-directory: ${{ inputs.go_project_dir_root }}
         run: go get -d ./...
       - name: Build


### PR DESCRIPTION
Bumping Go to a newer version to allow for heartbeat-client-lambdas to build using the `oapi-codegen` package who's transitive dependency requires 1.18+ 

- Tested it builds for 
  - https://github.com/useheartbeat/heartbeat-partner-api-spec/actions/runs/4177581685/jobs/7235331679
  - https://github.com/useheartbeat/heartbeat-client-lambdas/actions/runs/4177606708/jobs/7235386489