### PR TITLE
ATR-1785 Adding deploy action for client gateway

### DIFF
--- a/.github/workflows/go-cdk-deploy-client-gateway.yaml
+++ b/.github/workflows/go-cdk-deploy-client-gateway.yaml
@@ -1,0 +1,57 @@
+on:
+  workflow_call:
+    inputs:
+      env:
+        required: true
+        type: string
+      account-id:
+        required: true
+        type: string
+
+jobs:
+  aws_cdk:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/useheartbeat/heartbeat-go-cdk-dockerfile:main
+      credentials:
+        username: hbh-github
+        password: ${{ secrets.GH_TOKEN }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    name: Deploy
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+                        ${{ runner.os }}-go-
+
+      - name: Get modules
+        working-directory: ./cdk-infra
+        run: |
+          go mod download       
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ inputs.account-id }}:role/GitHubRole
+          role-session-name: actions-${{ inputs.env }}
+          aws-region: 'us-east-1'
+
+      - name: Clear context
+        working-directory: ./cdk-infra
+        run: cdk context --clear
+
+      - name: Deploy GW stack
+        working-directory: ./cdk-infra
+        run: cdk deploy --require-approval never -c envName=${{ inputs.env }} HBHClientImportVpcStack HBHClientApiGwStack
+


### PR DESCRIPTION
Creating a new deploy action because the existing `.github/workflows/go-cdk-deploy.yaml` step expects the `partner-api-spec` stacks and has multiple stack deploy steps. We could modify to take in variable name stacks but because the `go-cdk-deploy` requires several deployment stages it does not make sense for `client-gateway` which has a flat one time deploy