### PR TITLE
ATR-2626 migrate away from actions-rs

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -19,12 +19,6 @@ jobs:
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@stable
       - name: Run build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
+        run: cargo build --verbose
       - name: Run test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose

--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -17,9 +17,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Run build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust-format-lint.yaml
+++ b/.github/workflows/rust-format-lint.yaml
@@ -22,11 +22,6 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --check
+        run: cargo fmt --check
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+        run: cargo clippy

--- a/.github/workflows/rust-format-lint.yaml
+++ b/.github/workflows/rust-format-lint.yaml
@@ -18,9 +18,8 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install latest stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
       - name: Run rustfmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust-openapi-changes.yaml
+++ b/.github/workflows/rust-openapi-changes.yaml
@@ -17,9 +17,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Copy openapi.yaml
         run: cp openapi.yaml openapi.yaml_bak
         shell: bash

--- a/.github/workflows/rust-openapi-changes.yaml
+++ b/.github/workflows/rust-openapi-changes.yaml
@@ -22,9 +22,6 @@ jobs:
         run: cp openapi.yaml openapi.yaml_bak
         shell: bash
       - name: Generate OpenAPI specification
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin gen-openapi --verbose
+        run: cargo run --bin gen-openapi --verbose
       - name: Compare files
         run: diff --side-by-side openapi.yaml openapi.yaml_bak


### PR DESCRIPTION
the entire `actions-rs` org is no longer maintained as of sometime in 2020, xref:
- https://www.reddit.com/r/rust/comments/z1mlls/actionsrs_github_actions_need_more_maintainers_or/
- https://github.com/actions-rs/toolchain/issues/216
  - [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain/) is the well-maintained, well-used replacement
- https://github.com/actions-rs/cargo/issues/216
  - there's not a well-loved 1:1 replacement -- https://github.com/ructions/cargo is perhaps the most popular, with only 7 stars, but we don't require the [main use cases](https://github.com/ructions/cargo#use-cases) to justify using the action over plain `cargo`

Tested via 
- passing example:
  - this branch: https://github.com/useheartbeat/heartbeat-upload/actions/runs/5755556531
  - baseline: https://github.com/useheartbeat/heartbeat-upload/actions/runs/5755557638
- intentionally failing test example:
  - this branch: https://github.com/useheartbeat/heartbeat-upload/actions/runs/5762960788/job/15623773650
  - baseline: https://github.com/useheartbeat/heartbeat-upload/actions/runs/5762952339/job/15623746476
- intentionally failing lint example:
  - this branch: https://github.com/useheartbeat/heartbeat-upload/actions/runs/5763091486/job/15624198978
  - baseline: https://github.com/useheartbeat/heartbeat-upload/actions/runs/5763085235/job/15624179660

bonus: that this branch is faster than the baseline for the overall github action in all cases 🚀 