### PR TITLE
ATR-3237 expand cargo clippy targets

### DIFF
--- a/.github/workflows/rust-format-lint.yaml
+++ b/.github/workflows/rust-format-lint.yaml
@@ -24,4 +24,4 @@ jobs:
       - name: Run rustfmt
         run: cargo fmt --check
       - name: Run clippy
-        run: cargo clippy --all-features
+        run: cargo clippy --all-targets --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea
+.DS_Store


### PR DESCRIPTION
_see also:_
- https://github.com/useheartbeat/heartbeat-case/pull/367
- https://github.com/useheartbeat/heartbeat-message/pull/242

Note: some builds may fail until we update everything to be fully lint-compliant, but IMO it's better to merge this first to enforce that new code needs to follow the full lint