### PR TITLE
HD-663 Use larger runner on go deploy step job

### DIFF
--- a/.github/workflows/go-cdk-deploy.yaml
+++ b/.github/workflows/go-cdk-deploy.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   aws_cdk:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     container: 
       image: ghcr.io/useheartbeat/heartbeat-go-cdk-dockerfile:main
       credentials:


### PR DESCRIPTION


I don't know why would the runner run out of memory, but this would use a larger runner for the same action. I set up the larger runners
in:

useheartbeat org page => actions => runners => runner groups => default larger runners


@useheartbeat/engineering
