### PR TITLE
HD-834 don't do redundant action and turn down logging

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -18,5 +18,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@stable
+      - name: Run build
+        run: cargo build --profile test --verbose --all-features
       - name: Run test
-        run: cargo test --all-features
+        run: cargo test --verbose --all-features

--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -18,7 +18,5 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@stable
-      - name: Run build
-        run: cargo build --verbose --all-features
       - name: Run test
-        run: cargo test --verbose --all-features
+        run: cargo test --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 .DS_Store
 *.*~
+*.iml


### PR DESCRIPTION
We are still struggling with intermittent test failures.
* https://github.com/useheartbeat/heartbeat-case/actions/runs/10634464143
  * This one passed in PR and failed in prod deploy
* https://github.com/useheartbeat/heartbeat-case/actions/runs/10634674250/job/29482536194?pr=818
  * This one has taken 26 min so far!

My thought is MAAYBE turning down verbose logging could help.

Also I don't see why we need to build when we test already builds.

https://github.com/useheartbeat/heartbeat-case/actions/runs/10635088786/job/29483912019?pr=819 seems to give more stable results