### PR TITLE
HD-1473 Update Rust CI to include workspace in tests and linting

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -26,13 +26,13 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-  
+
       - name: Cache Cargo index
         uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-  
+
       - name: Cache Cargo build
         uses: actions/cache@v3
         with:
@@ -42,4 +42,4 @@ jobs:
             ${{ runner.os }}-cargo-build-
 
       - name: Run test
-        run: cargo test --verbose --all-features
+        run: cargo test --verbose --all-features --workspace

--- a/.github/workflows/rust-format-lint.yaml
+++ b/.github/workflows/rust-format-lint.yaml
@@ -29,13 +29,13 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-    
+
       - name: Cache Cargo index
         uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-  
+
       - name: Cache Cargo build
         uses: actions/cache@v3
         with:
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-cargo-build-
 
       - name: Run rustfmt
-        run: cargo fmt --check
+        run: cargo fmt --check --all
 
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features --all


### PR DESCRIPTION
Current CI is skipping workspace crates when doing linting and running tests