### PR TITLE
HD-1486 Configure rust CI to use sccache instead of github cache

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -8,9 +8,17 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_BUCKET: "hbh-sccache"
+  SCCACHE_REGION: "us-east-1"
+  SCCACHE_S3_KEY_PREFIX: ${{ github.event.repository.name }}
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -18,28 +26,19 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
+      - name: Configure AWS credentials
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::631720813209:role/GitHubRole
+          aws-region: us-east-1
+          role-session-name: actions-${{ inputs.env }}
+
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache Cargo index
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache Cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Run test
         run: cargo test --verbose --all-features --workspace

--- a/.github/workflows/rust-format-lint.yaml
+++ b/.github/workflows/rust-format-lint.yaml
@@ -8,9 +8,17 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_BUCKET: "hbh-sccache"
+  SCCACHE_REGION: "us-east-1"
+  SCCACHE_S3_KEY_PREFIX: ${{ github.event.repository.name }}
 jobs:
   lint:
     name: lint
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,30 +27,21 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
+      - name: Configure AWS credentials
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::631720813209:role/GitHubRole
+          aws-region: us-east-1
+          role-session-name: actions-${{ inputs.env }}
+
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache Cargo index
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache Cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Run rustfmt
         run: cargo fmt --check --all

--- a/.github/workflows/rust-openapi-changes.yaml
+++ b/.github/workflows/rust-openapi-changes.yaml
@@ -1,3 +1,4 @@
+
 name: Monitor OpenAPI changes
 on:
   workflow_call:
@@ -8,20 +9,44 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_BUCKET: "hbh-sccache"
+  SCCACHE_REGION: "us-east-1"
+  SCCACHE_S3_KEY_PREFIX: ${{ github.event.repository.name }}
 jobs:
   openapi:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
+
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Configure AWS credentials
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::631720813209:role/GitHubRole
+          aws-region: us-east-1
+          role-session-name: actions-${{ inputs.env }}
+
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Copy openapi.yaml
         run: cp openapi.yaml openapi.yaml_bak
         shell: bash
+
       - name: Generate OpenAPI specification
         run: cargo run --bin gen-openapi --verbose
+
       - name: Compare files
         run: diff --side-by-side openapi.yaml openapi.yaml_bak

--- a/.github/workflows/template-build.yaml
+++ b/.github/workflows/template-build.yaml
@@ -64,6 +64,7 @@ jobs:
           role-to-assume: arn:aws:iam::631720813209:role/GitHubRole
           aws-region: us-east-1
           role-session-name: actions-${{ inputs.env }}
+          output-credentials: true
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -90,10 +91,16 @@ jobs:
           IMAGE_TAG: ${{ steps.sha.outputs.sha_short }}
         run: |
           echo "building and pushing to: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          docker buildx build . -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --ssh default=${{ env.SSH_AUTH_SOCK }} \
+          docker buildx build \
+          --secret id=aws-access-key-id,env=AWS_ACCESS_KEY_ID \
+          --secret id=aws-secret-access-key,env=AWS_SECRET_ACCESS_KEY \
+          --secret id=aws-session-token,env=AWS_SESSION_TOKEN \
+          . -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+          --ssh default=${{ env.SSH_AUTH_SOCK }} \
           --cache-from type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:buildcache \
           --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:buildcache \
-          --build-arg githubUsername=hbh-github --build-arg githubToken=${{ secrets.GH_TOKEN }} --push
+          --build-arg githubUsername=hbh-github --build-arg githubToken=${{ secrets.GH_TOKEN }} \
+          --push
 
       - name: Check if branch is up to date
         id: checkCurrent


### PR DESCRIPTION
* Set all cargo actions to use sccache
* Update template-build to inject aws credentials as secrets to docker build so that they can be used by the docker builder to access s3 sccache bucket

## Improvements
### PR CI
A modest improvement 
#### Pre Change
<img width="319" alt="image" src="https://github.com/user-attachments/assets/596d1881-cfcb-4e41-a2a0-de1b956e7aa3" />

#### Post Change
<img width="320" alt="image" src="https://github.com/user-attachments/assets/f9be5849-dd84-4a12-bc28-65bb84c70f71" />

### Image building
Big improvement cutting build time in almost 1/4th
#### Pre Change
<img width="275" alt="image" src="https://github.com/user-attachments/assets/f748c7ef-b7b7-48f9-9581-a3abf8c13d88" />

#### Post Change
<img width="272" alt="image" src="https://github.com/user-attachments/assets/d2c87bc0-2620-4d61-a2f9-2447ac31413a" />

