### PR TITLE
HD-2757 Improve reliability of rust CI

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -21,6 +21,14 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Add 8G swap
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+
       - uses: actions/checkout@v4
 
       - uses: webfactory/ssh-agent@v0.9.1
@@ -41,13 +49,8 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run test
         run: cargo test --all-features --workspace

--- a/.github/workflows/rust-format-lint.yaml
+++ b/.github/workflows/rust-format-lint.yaml
@@ -43,13 +43,8 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run rustfmt
         run: cargo fmt --check --all

--- a/.github/workflows/rust-openapi-changes.yaml
+++ b/.github/workflows/rust-openapi-changes.yaml
@@ -48,13 +48,8 @@ jobs:
         run: cp ${{ inputs.openapi_file_name }} ${{ inputs.openapi_file_name }}_bak
         shell: bash
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Generate OpenAPI specification
         run: cargo run --bin gen-openapi --verbose


### PR DESCRIPTION
We are getting a bunch of instances of this

```
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/rustcDSuBoy/symbols.o" "<17 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/home/runner/work/heartbeat-case/heartbeat-case/target/debug/deps/{libmockito-226b9f9132a38bd8.rlib,libassert_json_diff-c2ad4dae7ab68204.rlib,libsimilar-d55a9a81a845c1ba.rlib,libcolored-2ec3c5a612c85523.rlib,libtextwrap-6449486e9165af3d.rlib,libunicode_linebreak-
```
In our rust tests.

This is due to the rust linker running out of memory